### PR TITLE
Upgrade to 0.8.4 list of changes:

### DIFF
--- a/contracts/Wrapper.sol
+++ b/contracts/Wrapper.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 /**
  *Submitted for verification at Etherscan.io on 2017-12-12
 */
@@ -17,7 +18,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.1;
+pragma solidity >=0.8.0;
 
 contract Wrapper {
     string public name     = "Wrapped Ether";
@@ -32,6 +33,8 @@ contract Wrapper {
     mapping (address => uint)                       public  balanceOf;
     mapping (address => mapping (address => uint))  public  allowance;
 
+    uint256 internal constant MAX_INT = 2**256 - 1;
+
     receive() external payable {
         deposit();
     }
@@ -42,7 +45,7 @@ contract Wrapper {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        payable(msg.sender).transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
@@ -66,7 +69,7 @@ contract Wrapper {
     {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != MAX_INT) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }

--- a/contracts/Yeeter.sol
+++ b/contracts/Yeeter.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.1;
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
 
 import "./MolochFlat.sol";
 import "./Wrapper.sol";
@@ -56,7 +57,7 @@ contract Yeeter {
         );
 
         // wrap
-        (bool success, ) = address(wrapper).call.value(newValue)("");
+        (bool success, ) = address(wrapper).call{value: newValue}("");
         require(success, "wrap failed");
         // send to dao
         require(
@@ -66,7 +67,7 @@ contract Yeeter {
 
         if (msg.value > newValue) {
             // Return the extra money to the minter.
-            (bool success2, ) = msg.sender.call.value(msg.value - newValue)("");
+            (bool success2, ) = msg.sender.call{value: msg.value - newValue}("");
             require(success2, "Transfer failed");
         }
 
@@ -101,7 +102,7 @@ contract Yeeter {
 
 contract CloneFactory1 {
     // implementation of eip-1167 - see https://eips.ethereum.org/EIPS/eip-1167
-    function createClone(address payable target) internal returns (address result) {
+    function createClone(address target) internal returns (address result) {
         bytes20 targetBytes = bytes20(target);
         assembly {
             let clone := mload(0x40)
@@ -126,7 +127,7 @@ contract YeetSummoner is CloneFactory1 {
 
     // Moloch private moloch; // moloch contract
 
-    constructor(address payable _template) public {
+    constructor(address payable _template) {
         template = _template;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11643,6 +11643,67 @@
         }
       }
     },
+    "hardhat-contract-sizer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.1.1.tgz",
+      "integrity": "sha512-QgfuwdUkKT7Ugn6Zja26Eie7h6OLcBfWBewaaQtYMCzyglNafQPgUIznN2C42/iFmGrlqFPbqv4B98Iev89KSQ==",
+      "dev": true,
+      "requires": {
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "cli-table3": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+          "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+          "dev": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "hardhat-gas-reporter": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.6.tgz",


### PR DESCRIPTION
-Add SPDX-License-Identifier
-New syntax for abstract functions
-Remove SafeMath
-Change functional math to operators
-Extract votesByMember from Proposal to top level mapping voteHistory as
compiler will not ignore nested mapping in struct and will throw errors when you try to create new structs
-Change setters and getters to use new voteHistory mapping
-Exchange "now" for block.timestamp
-Update withdraw function param name "max" to "shouldWithdrawMax" to avoid conflict with
contract function name "max"
-Change shorthand uint(-1) to const MAX_INT as shorthand no longer works
-Cast msg.sender as payable because transfer needs a payable address
-New syntax for address.call(value)() to address.call{value:value}()
-createClone in Yeeter changed to address from payable address as bytes20
casting failed and I could see no reason it needed to be a payable

Code compiles and passes the tests in the repo.  There should be no functionality change.  Some of the changes were done to ensure that there were no warnings in the new compiler.